### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ NN(\rave).methods;
 
 
 // 2. play
-{ NN(\rave, \forward).ar(1024, WhiteNoise.ar) }.play;
+{ NN(\rave, \forward).ar(WhiteNoise.ar, 1024) }.play;
 
 NN.load(\msprior, "~/rave/msprior.ts", action: _.describe);
 
@@ -35,12 +35,12 @@ NN.load(\msprior, "~/rave/msprior.ts", action: _.describe);
     var in, latent, modLatent, prior, resynth;
 
     in = SoundIn.ar();
-    latent = NN(\rave, \encode).ar(2048, in);
+    latent = NN(\rave, \encode).ar(in, 1024);
     modLatent = latent.collect { |l|
         l + LFNoise1.ar(MouseY.kr.exprange(0.1, 30)).range(-0.5, 0.5)
     };
-    prior = NN(\msprior, \forward).ar(2048, latent);
-    resynth = NN(\rave, \decode).ar(2048, prior.drop(-1);
+    prior = NN(\msprior, \forward).ar(latent, 1024);
+    resynth = NN(\rave, \decode).ar(prior.drop(-1), 2048);
 
     resynth
 }.play;
@@ -54,11 +54,11 @@ NN(\msprior).attributes;
     var in, latent, modLatent, prior, resynth;
 
     in = SoundIn.ar();
-    latent = NN(\rave, \encode).ar(2048, in);
+    latent = NN(\rave, \encode).ar(in, 2048);
     modLatent = latent.collect { |l|
         l + LFNoise1.ar(MouseY.kr.exprange(0.1, 30)).range(-0.5, 0.5)
     };
-    prior = NN(\msprior, \forward).ar(2048, latent
+    prior = NN(\msprior, \forward).ar(latent, 2048
         // attributes are set when their value changes
         attributes: [
             // here we use latch to limit the setting rate to once per second
@@ -66,7 +66,7 @@ NN(\msprior).attributes;
         ],
         debug: 1 // print attribute values when setting them
     );
-    resynth = NN(\rave, \decode).ar(2048, prior.drop(-1);
+    resynth = NN(\rave, \decode).ar(prior.drop(-1), 2048);
 
     resynth
 }.play;

--- a/plugins/NNModel/schelp/NNUGen.schelp
+++ b/plugins/NNModel/schelp/NNUGen.schelp
@@ -48,11 +48,11 @@ s.reboot.waitForBoot {
 	// drive with a sine wave sound
 	var in = SinOsc.ar(MouseX.kr.exprange(20,20000));
 	// encode input sound to latent space
-	var latent = NN(\rave, \encode).ar(1024, in);
+	var latent = NN(\rave, \encode).ar(in, 1024);
 	// modulate latent space trajectories...
 	var mod = latent.collect {|l| l + LFNoise1.ar(1).range(-1,1) };
 	// resynth
-	NN(\rave, \decode).ar(1024, mod);
+	NN(\rave, \decode).ar(mod, 1024);
 }.play
 )
 
@@ -60,12 +60,12 @@ s.reboot.waitForBoot {
 {
 	var in = WhiteNoise.ar();
 	// encode input sound to latent space
-	var latent = NN(\rave, \encode).ar(1024, in);
+	var latent = NN(\rave, \encode).ar(in, 1024);
 	// generate new latent codes with msprior
-	var prior = NN(\prior, \forward).ar(1024, latent);
+	var prior = NN(\prior, \forward).ar(latent, 1024);
 	// resynth latent codes to sound out
 	// dropping the last prior element because msprior returns perplexity as 9th output
-	var resynth = NN(\rave, \decode).ar(1024, prior.drop(-1));
+	var resynth = NN(\rave, \decode).ar(prior.drop(-1), 1024);
 
 	resynth;
 }.play


### PR DESCRIPTION
Fixed example implementation in the readme to have the correct order of parameters. Input then block size instead of the other way around.