### PR TITLE
Add m_debug variable

### DIFF
--- a/plugins/NNModel/cpp/NNUGens.cpp
+++ b/plugins/NNModel/cpp/NNUGens.cpp
@@ -140,6 +140,7 @@ inline void set_thread_rt_prio(const NN* nn_instance) {
     double ns_to_host = static_cast<double>(timebase.denom) / timebase.numer;
     int computation = ns_to_host * (ns_per_block - 5000);
     int constraint = ns_to_host * ns_per_block;
+    auto m_debug = nn_instance->m_debug;
     DEBUG("NNUGen: setting thread rt prio (ns_to_host: %f; computation: %d, constraint: %d)\n",
           ns_to_host, computation, constraint);
     success = nova::thread_set_priority_rt(0, computation, constraint, true);


### PR DESCRIPTION
While compiling on macOS x64 (which is necessary b/c only arm64 macOS binaries are provided) I ran into the following problem

```shell
❯ cmake --build build --config Release --target install
[  8%] Building CXX object CMakeFiles/NNUGens_scsynth.dir/plugins/NNModel/cpp/NNUGens.cpp.o
/Users/scheiba/github/nn.ar/plugins/NNModel/cpp/NNUGens.cpp:143:5: error: use of undeclared identifier 'm_debug'
  143 |     DEBUG("NNUGen: setting thread rt prio (ns_to_host: %f; computation: %d, constraint: %d)\n",
      |     ^
/Users/scheiba/github/nn.ar/plugins/NNModel/cpp/NNUGens.cpp:14:24: note: expanded from macro 'DEBUG'
   14 | #define DEBUG(...) if (m_debug >= Debug::all) Print(__VA_ARGS__)
      |                        ^
1 error generated.
make[2]: *** [CMakeFiles/NNUGens_scsynth.dir/plugins/NNModel/cpp/NNUGens.cpp.o] Error 1
make[1]: *** [CMakeFiles/NNUGens_scsynth.dir/all] Error 2
make: *** [all] Error 2
```

This patch fixes this bug by adding the `m_debug` variable for this conditional block.